### PR TITLE
Implement basic user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,9 @@ KeepUp aims to be scalable with features such as:
 - Free users with limited permissions
 - Custom fields for tasks
 
+## Authentication
+
+Use `/auth/register` to create a new user with a JSON body containing `username` and `password`. Log in via `/auth/login` with the same fields to receive a JWT token.
+
 This README outlines the current vision and early development goals for KeepUp. The codebase is intentionally minimal as the project is in its initial stages.
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,16 @@
     "@prisma/client": "^6.9.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",
     "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^22.15.30",
+    "@types/bcryptjs": "^2.4.2",
     "prisma": "^6.9.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,10 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model User {
+  id        Int      @id @default(autoincrement())
+  username  String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,53 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
 
 dotenv.config();
 
 const app = express();
+const prisma = new PrismaClient();
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 // Middleware
 app.use(cors());
 app.use(express.json());
+
+// Register new user
+app.post('/auth/register', async (req, res) => {
+  const { username, password } = req.body as { username?: string; password?: string };
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  const existing = await prisma.user.findUnique({ where: { username } });
+  if (existing) {
+    return res.status(409).json({ error: 'Username already exists' });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({ data: { username, password: hashed } });
+  const token = jwt.sign({ userId: user.id }, JWT_SECRET);
+  res.json({ token });
+});
+
+// Login existing user
+app.post('/auth/login', async (req, res) => {
+  const { username, password } = req.body as { username?: string; password?: string };
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  const user = await prisma.user.findUnique({ where: { username } });
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ userId: user.id }, JWT_SECRET);
+  res.json({ token });
+});
 
 // Health-check route
 app.get('/health', (_req, res) => {


### PR DESCRIPTION
## Summary
- create a `User` model in Prisma
- add routes for registering and logging in users
- add bcrypt and JWT dependencies
- document authentication routes in the README

## Testing
- `npm run build` *(fails: Cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_b_6844e9736b448320b4d0a037dd181339