### PR TITLE
Implement basic user roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The initial goal is to build a functional foundation that can grow in the future
 - Ability to create new accounts and add users under an account ID
 - User authentication with username and password (with optional Gmail or Microsoft linkage)
 - Admin and basic user roles (future permissions can be added later)
+
+## Role Management
+KeepUp now defines two user roles: `ADMIN` and `BASIC`. Future permission settings will be added to these roles as the project evolves.
 - Restrict user access to certain projects
 - User home page showing only their tasks
 - Company and project hierarchy:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,17 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+enum Role {
+  ADMIN
+  BASIC
+}
+
+model User {
+  id          Int      @id @default(autoincrement())
+  username    String   @unique
+  password    String
+  role        Role     @default(BASIC)
+  permissions Json?
+  createdAt   DateTime @default(now())
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import { requireAdmin } from './middleware/requireAdmin';
 
 dotenv.config();
 
@@ -14,6 +15,11 @@ app.use(express.json());
 // Health-check route
 app.get('/health', (_req, res) => {
   res.status(200).send('OK');
+});
+
+// Example protected admin route
+app.get('/admin', requireAdmin, (_req, res) => {
+  res.status(200).json({ message: 'Admin access granted' });
 });
 
 // Start

--- a/src/middleware/requireAdmin.ts
+++ b/src/middleware/requireAdmin.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+import { UserRole } from '../roles';
+
+// Simple placeholder middleware to restrict routes to admins.
+export function requireAdmin(req: Request, res: Response, next: NextFunction) {
+  // In the future, extract user role from authentication token
+  const role = (req as any).userRole as UserRole | undefined;
+  if (role === UserRole.ADMIN) {
+    return next();
+  }
+  return res.status(403).json({ message: 'Admin access required' });
+}

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -1,0 +1,10 @@
+export enum UserRole {
+  ADMIN = 'ADMIN',
+  BASIC = 'BASIC',
+}
+
+// Placeholder for future permission flags
+export interface RolePermissions {
+  // e.g., canEditUsers?: boolean
+  // more granular permissions will be added here later
+}


### PR DESCRIPTION
## Summary
- add `UserRole` enum and `RolePermissions` placeholder
- enforce admin-only route with `requireAdmin` middleware
- define `Role` enum and `User` model in Prisma schema
- document role management in README

## Testing
- `npm run build` *(fails: Cannot find type definition file for several packages)*

------
https://chatgpt.com/codex/tasks/task_b_6844e98daf108320889c9f3d7c834418