### PR TITLE
Add project categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,16 @@ Use `/auth/register` to create a new user with a JSON body containing `username`
 
 This README outlines the current vision and early development goals for KeepUp. The codebase is intentionally minimal as the project is in its initial stages.
 
+## Project Categories API
+
+Projects can be grouped into categories for better organization. Use the
+following endpoints to manage them:
+
+- `POST /categories` - create a category
+- `GET /categories` - list categories (filter by `accountId` query param)
+- `PATCH /categories/:id` - rename a category
+- `DELETE /categories/:id` - remove a category
+
+When creating a project via `POST /projects`, omit `categoryId` to automatically
+place it in the `Uncategorized` group for its account.
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,3 +41,24 @@ model User {
 
   @@unique([accountId, username])
 }
+
+model ProjectCategory {
+  id        Int      @id @default(autoincrement())
+  name      String
+  account   Account  @relation(fields: [accountId], references: [id])
+  accountId Int
+  createdAt DateTime @default(now())
+
+  projects  Project[]
+}
+
+model Project {
+  id        Int      @id @default(autoincrement())
+  name      String
+  account   Account  @relation(fields: [accountId], references: [id])
+  accountId Int
+  createdAt DateTime @default(now())
+
+  category   ProjectCategory? @relation(fields: [categoryId], references: [id])
+  categoryId Int?
+}

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -1,0 +1,84 @@
+import { Request, Response } from 'express';
+import {
+  categories,
+  projects,
+  getOrCreateDefaultCategory,
+  Project,
+  ProjectCategory,
+} from '../models/Project';
+
+let categoryCounter = 1;
+let projectCounter = 1;
+
+export const createCategory = (req: Request, res: Response) => {
+  const { name, accountId } = req.body as { name?: string; accountId?: number };
+  if (!name || !accountId) {
+    return res.status(400).json({ error: 'Name and accountId required' });
+  }
+  const category: ProjectCategory = {
+    id: categoryCounter++,
+    name,
+    accountId,
+    createdAt: new Date(),
+  };
+  categories.push(category);
+  res.status(201).json(category);
+};
+
+export const listCategories = (req: Request, res: Response) => {
+  const accountId = Number(req.query.accountId);
+  const result = Number.isNaN(accountId)
+    ? categories
+    : categories.filter((c) => c.accountId === accountId);
+  res.json(result);
+};
+
+export const updateCategory = (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const category = categories.find((c) => c.id === id);
+  if (!category) {
+    return res.status(404).json({ error: 'Category not found' });
+  }
+  category.name = req.body.name ?? category.name;
+  res.json(category);
+};
+
+export const deleteCategory = (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const index = categories.findIndex((c) => c.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Category not found' });
+  }
+  categories.splice(index, 1);
+  projects.forEach((p) => {
+    if (p.categoryId === id) {
+      p.categoryId = undefined;
+    }
+  });
+  res.status(204).send();
+};
+
+export const createProject = (req: Request, res: Response) => {
+  const { name, accountId, categoryId } = req.body as {
+    name?: string;
+    accountId?: number;
+    categoryId?: number;
+  };
+  if (!name || !accountId) {
+    return res.status(400).json({ error: 'Name and accountId required' });
+  }
+  let catId = categoryId;
+  if (!catId) {
+    const defaultCat = getOrCreateDefaultCategory(accountId);
+    catId = defaultCat.id;
+  }
+  const project: Project = {
+    id: projectCounter++,
+    name,
+    accountId,
+    createdAt: new Date(),
+    categoryId: catId,
+  };
+  projects.push(project);
+  res.status(201).json(project);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import boardRoutes from './routes/boards';
+import projectRoutes from './routes/projects';
 dotenv.config();
 
 const app = express();
@@ -22,6 +23,7 @@ const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 app.use(cors());
 app.use(express.json());
 app.use(boardRoutes);
+app.use(projectRoutes);
 
 // Register new user
 app.post('/auth/register', async (req, res) => {

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -1,0 +1,33 @@
+export interface ProjectCategory {
+  id: number;
+  name: string;
+  accountId: number;
+  createdAt: Date;
+}
+
+export interface Project {
+  id: number;
+  name: string;
+  accountId: number;
+  createdAt: Date;
+  categoryId?: number;
+}
+
+export const categories: ProjectCategory[] = [];
+export const projects: Project[] = [];
+
+export function getOrCreateDefaultCategory(accountId: number): ProjectCategory {
+  let cat = categories.find(
+    (c) => c.accountId === accountId && c.name === 'Uncategorized'
+  );
+  if (!cat) {
+    cat = {
+      id: categories.length + 1,
+      name: 'Uncategorized',
+      accountId,
+      createdAt: new Date(),
+    };
+    categories.push(cat);
+  }
+  return cat;
+}

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import {
+  createCategory,
+  listCategories,
+  updateCategory,
+  deleteCategory,
+  createProject,
+} from '../controllers/projectController';
+
+const router = Router();
+
+router.post('/categories', createCategory);
+router.get('/categories', listCategories);
+router.patch('/categories/:id', updateCategory);
+router.delete('/categories/:id', deleteCategory);
+
+router.post('/projects', createProject);
+
+export default router;

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import app from '../src/index';
+import { categories, projects } from '../src/models/Project';
+
+describe('Project categories API', () => {
+  beforeEach(() => {
+    categories.length = 0;
+    projects.length = 0;
+  });
+
+  it('creates, updates and deletes categories', async () => {
+    const create = await request(app)
+      .post('/categories')
+      .send({ name: 'Cat A', accountId: 1 });
+    expect(create.status).toBe(201);
+    const id = create.body.id;
+
+    let list = await request(app).get('/categories');
+    expect(list.body.length).toBe(1);
+
+    const update = await request(app)
+      .patch(`/categories/${id}`)
+      .send({ name: 'Cat B' });
+    expect(update.body.name).toBe('Cat B');
+
+    await request(app).delete(`/categories/${id}`).expect(204);
+    list = await request(app).get('/categories');
+    expect(list.body.length).toBe(0);
+  });
+
+  it('assigns default category when creating a project', async () => {
+    const res = await request(app)
+      .post('/projects')
+      .send({ name: 'Proj', accountId: 2 });
+    expect(res.status).toBe(201);
+    expect(res.body.categoryId).toBeDefined();
+    const cats = await request(app).get('/categories?accountId=2');
+    expect(cats.body[0].name).toBe('Uncategorized');
+  });
+});


### PR DESCRIPTION
## Summary
- create `ProjectCategory` and `Project` models in Prisma schema
- implement in-memory models and controllers for categories and projects
- expose `/categories` CRUD routes and `/projects` creation route
- document new API endpoints
- test categories API

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844f62d45d88320866f965ef0e39bac