### PR TITLE
Implement Task creation and retrieval

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model User {
   account   Account @relation(fields: [accountId], references: [id])
   accountId Int
 
+  tasks Task[]
+
   @@unique([accountId, username])
 }
 
@@ -62,3 +64,24 @@ model Project {
   category   ProjectCategory? @relation(fields: [categoryId], references: [id])
   categoryId Int?
 }
+
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+model Task {
+  id          Int       @id @default(autoincrement())
+  taskId      String    @unique
+  name        String
+  description String?
+  startDate   DateTime?
+  dueDate     DateTime?
+  priority    Priority  @default(MEDIUM)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  assignedUsers User[]
+}
+

--- a/src/controllers/taskController.ts
+++ b/src/controllers/taskController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { tasks, Task } from '../models/Task';
+
+let idCounter = 1;
+
+function generateShortId() {
+  return Math.random().toString(36).substring(2, 8);
+}
+
+export const createTask = (req: Request, res: Response) => {
+  const { name, description, startDate, dueDate, priority, assignedUserIds } =
+    req.body as Partial<Omit<Task, 'id' | 'taskId' | 'createdAt' | 'updatedAt'>> & {
+      assignedUserIds?: number[];
+    };
+
+  if (!name) {
+    return res.status(400).json({ error: 'Name required' });
+  }
+  if (assignedUserIds && !Array.isArray(assignedUserIds)) {
+    return res.status(400).json({ error: 'assignedUserIds must be an array' });
+  }
+
+  const now = new Date();
+  const task: Task = {
+    id: idCounter++,
+    taskId: generateShortId(),
+    name,
+    description,
+    startDate: startDate ? new Date(startDate) : undefined,
+    dueDate: dueDate ? new Date(dueDate) : undefined,
+    priority: (priority as Task['priority']) || 'MEDIUM',
+    createdAt: now,
+    updatedAt: now,
+    assignedUserIds: assignedUserIds || [],
+  };
+  tasks.push(task);
+  res.status(201).json(task);
+};
+
+export const getTask = (req: Request, res: Response) => {
+  const { taskId } = req.params;
+  const task = tasks.find((t) => t.taskId === taskId);
+  if (!task) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  res.json(task);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import boardRoutes from './routes/boards';
 import projectRoutes from './routes/projects';
+import taskRoutes from './routes/tasks';
 dotenv.config();
 
 const app = express();
@@ -24,6 +25,7 @@ app.use(cors());
 app.use(express.json());
 app.use(boardRoutes);
 app.use(projectRoutes);
+app.use(taskRoutes);
 
 // Register new user
 app.post('/auth/register', async (req, res) => {

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,0 +1,14 @@
+export interface Task {
+  id: number;
+  taskId: string;
+  name: string;
+  description?: string;
+  startDate?: Date;
+  dueDate?: Date;
+  priority: 'LOW' | 'MEDIUM' | 'HIGH';
+  createdAt: Date;
+  updatedAt: Date;
+  assignedUserIds: number[];
+}
+
+export const tasks: Task[] = [];

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { createTask, getTask } from '../controllers/taskController';
+
+const router = Router();
+
+router.post('/tasks', createTask);
+router.get('/tasks/:taskId', getTask);
+
+export default router;

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import app from '../src/index';
+import { tasks } from '../src/models/Task';
+
+describe('Tasks API', () => {
+  beforeEach(() => {
+    tasks.length = 0;
+  });
+
+  it('creates and retrieves a task', async () => {
+    const res = await request(app).post('/tasks').send({
+      name: 'New Task',
+      description: 'Test',
+      startDate: '2024-01-01T00:00:00.000Z',
+      dueDate: '2024-01-05T00:00:00.000Z',
+      priority: 'HIGH',
+      assignedUserIds: [1, 2],
+    });
+    expect(res.status).toBe(201);
+    const taskId = res.body.taskId;
+    expect(taskId).toBeDefined();
+
+    const getRes = await request(app).get(`/tasks/${taskId}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.name).toBe('New Task');
+    expect(getRes.body.assignedUserIds.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- extend Prisma schema with a `Task` model and `Priority` enum
- allow `User` model to reference tasks
- add in-memory `Task` model and storage
- provide controller and routes for creating and reading tasks
- expose task routes via Express app
- test task API for creation and retrieval

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844f7ca59cc8320aca0e00e87a50eb1