### PR TITLE
Add progress, tags, and time logging to tasks

### DIFF
--- a/src/controllers/taskController.ts
+++ b/src/controllers/taskController.ts
@@ -1,7 +1,11 @@
 import { Request, Response } from 'express';
 import { tasks, Task } from '../models/Task';
+import { timeLogs, TimeLog } from '../models/TimeLog';
+import { tags as tagStore, Tag } from '../models/Tag';
 
 let idCounter = 1;
+let timeLogCounter = 1;
+let tagIdCounter = 1;
 
 function generateShortId() {
   return Math.random().toString(36).substring(2, 8);
@@ -32,6 +36,8 @@ export const createTask = (req: Request, res: Response) => {
     createdAt: now,
     updatedAt: now,
     assignedUserIds: assignedUserIds || [],
+    progress: 0,
+    tagIds: [],
   };
   tasks.push(task);
   res.status(201).json(task);
@@ -43,5 +49,72 @@ export const getTask = (req: Request, res: Response) => {
   if (!task) {
     return res.status(404).json({ error: 'Task not found' });
   }
+  res.json(task);
+};
+
+export const logTime = (req: Request, res: Response) => {
+  const { taskId } = req.params;
+  const task = tasks.find((t) => t.taskId === taskId);
+  if (!task) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  const { start, end } = req.body as { start?: string; end?: string };
+  if (!start || !end) {
+    return res.status(400).json({ error: 'start and end required' });
+  }
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    return res.status(400).json({ error: 'Invalid dates' });
+  }
+  const totalMs = endDate.getTime() - startDate.getTime();
+  const log: TimeLog = {
+    id: timeLogCounter++,
+    taskId,
+    start: startDate,
+    end: endDate,
+    totalMs,
+  };
+  timeLogs.push(log);
+  res.status(201).json(log);
+};
+
+export const updateProgress = (req: Request, res: Response) => {
+  const { taskId } = req.params;
+  const task = tasks.find((t) => t.taskId === taskId);
+  if (!task) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  const { progress } = req.body as { progress?: number };
+  if (typeof progress !== 'number' || progress < 0 || progress > 100) {
+    return res.status(400).json({ error: 'progress must be 0-100' });
+  }
+  task.progress = progress;
+  task.updatedAt = new Date();
+  res.json(task);
+};
+
+export const createTag = (req: Request, res: Response) => {
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ error: 'Name required' });
+  }
+  const tag: Tag = { id: tagIdCounter++, name };
+  tagStore.push(tag);
+  res.status(201).json(tag);
+};
+
+export const updateTaskTags = (req: Request, res: Response) => {
+  const { taskId } = req.params;
+  const task = tasks.find((t) => t.taskId === taskId);
+  if (!task) {
+    return res.status(404).json({ error: 'Task not found' });
+  }
+  const { tagIds } = req.body as { tagIds?: number[] };
+  if (!Array.isArray(tagIds)) {
+    return res.status(400).json({ error: 'tagIds must be array' });
+  }
+  task.tagIds = tagIds;
+  task.updatedAt = new Date();
   res.json(task);
 };

--- a/src/models/Tag.ts
+++ b/src/models/Tag.ts
@@ -1,0 +1,6 @@
+export interface Tag {
+  id: number;
+  name: string;
+}
+
+export const tags: Tag[] = [];

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -9,6 +9,8 @@ export interface Task {
   createdAt: Date;
   updatedAt: Date;
   assignedUserIds: number[];
+  progress: number;
+  tagIds: number[];
 }
 
 export const tasks: Task[] = [];

--- a/src/models/TimeLog.ts
+++ b/src/models/TimeLog.ts
@@ -1,0 +1,9 @@
+export interface TimeLog {
+  id: number;
+  taskId: string;
+  start: Date;
+  end: Date;
+  totalMs: number;
+}
+
+export const timeLogs: TimeLog[] = [];

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -1,9 +1,20 @@
 import { Router } from 'express';
-import { createTask, getTask } from '../controllers/taskController';
+import {
+  createTask,
+  getTask,
+  logTime,
+  updateProgress,
+  createTag,
+  updateTaskTags,
+} from '../controllers/taskController';
 
 const router = Router();
 
 router.post('/tasks', createTask);
 router.get('/tasks/:taskId', getTask);
+router.post('/tasks/:taskId/timelogs', logTime);
+router.patch('/tasks/:taskId/progress', updateProgress);
+router.patch('/tasks/:taskId/tags', updateTaskTags);
+router.post('/tags', createTag);
 
 export default router;

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -1,10 +1,14 @@
 import request from 'supertest';
 import app from '../src/index';
 import { tasks } from '../src/models/Task';
+import { timeLogs } from '../src/models/TimeLog';
+import { tags } from '../src/models/Tag';
 
 describe('Tasks API', () => {
   beforeEach(() => {
     tasks.length = 0;
+    timeLogs.length = 0;
+    tags.length = 0;
   });
 
   it('creates and retrieves a task', async () => {
@@ -24,5 +28,30 @@ describe('Tasks API', () => {
     expect(getRes.status).toBe(200);
     expect(getRes.body.name).toBe('New Task');
     expect(getRes.body.assignedUserIds.length).toBe(2);
+  });
+
+  it('logs time and computes total', async () => {
+    const create = await request(app).post('/tasks').send({ name: 'T' });
+    const taskId = create.body.taskId;
+    const log = await request(app)
+      .post(`/tasks/${taskId}/timelogs`)
+      .send({
+        start: '2024-01-01T00:00:00.000Z',
+        end: '2024-01-01T01:00:00.000Z',
+      });
+    expect(log.status).toBe(201);
+    expect(log.body.totalMs).toBe(3600000);
+  });
+
+  it('assigns tags to a task', async () => {
+    const tag = await request(app).post('/tags').send({ name: 'bug' });
+    const tagId = tag.body.id;
+    const create = await request(app).post('/tasks').send({ name: 'T2' });
+    const taskId = create.body.taskId;
+    const update = await request(app)
+      .patch(`/tasks/${taskId}/tags`)
+      .send({ tagIds: [tagId] });
+    expect(update.status).toBe(200);
+    expect(update.body.tagIds).toContain(tagId);
   });
 });


### PR DESCRIPTION
## Summary
- track task progress and tags
- record time logs on tasks
- expose new endpoints for progress, tags, and timelogs
- test time log totals and tag updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844f8f6a31483209096fc82e57c9edb