### PR TITLE
Implement comments, followers, and repeat tasks

### DIFF
--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+  id: number;
+  taskId: string;
+  userId: number;
+  text: string;
+  createdAt: Date;
+  mentions: string[];
+}
+
+export const comments: Comment[] = [];

--- a/src/models/Follower.ts
+++ b/src/models/Follower.ts
@@ -1,0 +1,6 @@
+export interface Follower {
+  taskId: string;
+  userId: number;
+}
+
+export const followers: Follower[] = [];

--- a/src/models/RepeatSetting.ts
+++ b/src/models/RepeatSetting.ts
@@ -1,0 +1,9 @@
+export type RepeatPattern = 'DAILY' | 'WEEKLY';
+
+export interface RepeatSetting {
+  taskId: string;
+  pattern: RepeatPattern;
+  lastGenerated?: Date;
+}
+
+export const repeatSettings: RepeatSetting[] = [];

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -6,6 +6,11 @@ import {
   updateProgress,
   createTag,
   updateTaskTags,
+  addComment,
+  getComments,
+  toggleFollow,
+  setRepeat,
+  processRepeatsHandler,
 } from '../controllers/taskController';
 
 const router = Router();
@@ -16,5 +21,10 @@ router.post('/tasks/:taskId/timelogs', logTime);
 router.patch('/tasks/:taskId/progress', updateProgress);
 router.patch('/tasks/:taskId/tags', updateTaskTags);
 router.post('/tags', createTag);
+router.post('/tasks/:taskId/comments', addComment);
+router.get('/tasks/:taskId/comments', getComments);
+router.post('/tasks/:taskId/followers', toggleFollow);
+router.post('/tasks/:taskId/repeat', setRepeat);
+router.post('/tasks/process-repeats', processRepeatsHandler);
 
 export default router;


### PR DESCRIPTION
## Summary
- add Comment, Follower and RepeatSetting in-memory models
- extend task controller with comment, follower, and repeat logic
- add endpoints for comments, followers, repeating tasks, and process repeats
- implement mention parsing and notification stubs
- test mention parsing and repeat task creation logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844fc39a02883209036e0553f3762ed