### PR TITLE
Implement project access control

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,3 +85,13 @@ model Task {
   assignedUsers User[]
 }
 
+model UserProjectAccess {
+  user     User    @relation(fields: [userId], references: [id])
+  userId   Int
+  project  Project @relation(fields: [projectId], references: [id])
+  projectId Int
+  role     String?
+
+  @@id([userId, projectId])
+}
+

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -82,3 +82,22 @@ export const createProject = (req: Request, res: Response) => {
   projects.push(project);
   res.status(201).json(project);
 };
+
+export const getProject = (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+  res.json(project);
+};
+
+export const updateProject = (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+  project.name = req.body.name ?? project.name;
+  res.json(project);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ app.post('/auth/register', async (req, res) => {
   }
   const hashed = await bcrypt.hash(password, 10);
   const user = await prisma.user.create({ data: { username, password: hashed } });
-  const token = jwt.sign({ userId: user.id }, JWT_SECRET);
+  const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
   res.json({ token });
 });
 
@@ -57,7 +57,7 @@ app.post('/auth/login', async (req, res) => {
   if (!valid) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
-  const token = jwt.sign({ userId: user.id }, JWT_SECRET);
+  const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
   res.json({ token });
 });
 

--- a/src/middleware/authorizeProjectAccess.ts
+++ b/src/middleware/authorizeProjectAccess.ts
@@ -1,0 +1,40 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { userProjectAccess } from '../models/UserProjectAccess';
+import { UserRole } from '../roles';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+export function authorizeProjectAccess(projectIdParamKey: string) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const auth = req.headers.authorization;
+    if (!auth || !auth.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Authorization required' });
+    }
+    try {
+      const token = auth.split(' ')[1];
+      const payload = jwt.verify(token, JWT_SECRET) as any;
+      const userId = payload.userId as number | undefined;
+      const role = payload.role as UserRole | undefined;
+      if (!userId) {
+        return res.status(401).json({ error: 'Invalid token' });
+      }
+      (req as any).userId = userId;
+      (req as any).userRole = role;
+      if (role === UserRole.ADMIN) {
+        return next();
+      }
+      const projectId = Number(req.params[projectIdParamKey]);
+      if (
+        userProjectAccess.some(
+          (a) => a.userId === userId && a.projectId === projectId
+        )
+      ) {
+        return next();
+      }
+      return res.status(403).json({ error: 'Forbidden' });
+    } catch {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+  };
+}

--- a/src/models/UserProjectAccess.ts
+++ b/src/models/UserProjectAccess.ts
@@ -1,0 +1,7 @@
+export interface UserProjectAccess {
+  userId: number;
+  projectId: number;
+  role?: string; // e.g., viewer/editor
+}
+
+export const userProjectAccess: UserProjectAccess[] = [];

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -5,7 +5,10 @@ import {
   updateCategory,
   deleteCategory,
   createProject,
+  getProject,
+  updateProject,
 } from '../controllers/projectController';
+import { authorizeProjectAccess } from '../middleware/authorizeProjectAccess';
 
 const router = Router();
 
@@ -15,5 +18,7 @@ router.patch('/categories/:id', updateCategory);
 router.delete('/categories/:id', deleteCategory);
 
 router.post('/projects', createProject);
+router.get('/projects/:id', authorizeProjectAccess('id'), getProject);
+router.patch('/projects/:id', authorizeProjectAccess('id'), updateProject);
 
 export default router;

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -1,11 +1,16 @@
 import request from 'supertest';
 import app from '../src/index';
 import { categories, projects } from '../src/models/Project';
+import { userProjectAccess } from '../src/models/UserProjectAccess';
+import jwt from 'jsonwebtoken';
+
+const SECRET = process.env.JWT_SECRET || 'secret';
 
 describe('Project categories API', () => {
   beforeEach(() => {
     categories.length = 0;
     projects.length = 0;
+    userProjectAccess.length = 0;
   });
 
   it('creates, updates and deletes categories', async () => {
@@ -36,5 +41,49 @@ describe('Project categories API', () => {
     expect(res.body.categoryId).toBeDefined();
     const cats = await request(app).get('/categories?accountId=2');
     expect(cats.body[0].name).toBe('Uncategorized');
+  });
+});
+
+describe('Project access control', () => {
+  beforeEach(() => {
+    projects.length = 0;
+    userProjectAccess.length = 0;
+  });
+
+  it('denies access when user lacks permission', async () => {
+    const create = await request(app)
+      .post('/projects')
+      .send({ name: 'A', accountId: 1 });
+    const id = create.body.id;
+    const token = jwt.sign({ userId: 1, role: 'BASIC' }, SECRET);
+    const res = await request(app)
+      .get(`/projects/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('allows access when entry exists', async () => {
+    const create = await request(app)
+      .post('/projects')
+      .send({ name: 'A', accountId: 1 });
+    const id = create.body.id;
+    userProjectAccess.push({ userId: 1, projectId: id });
+    const token = jwt.sign({ userId: 1, role: 'BASIC' }, SECRET);
+    const res = await request(app)
+      .get(`/projects/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('allows admin regardless of entry', async () => {
+    const create = await request(app)
+      .post('/projects')
+      .send({ name: 'A', accountId: 1 });
+    const id = create.body.id;
+    const token = jwt.sign({ userId: 2, role: 'ADMIN' }, SECRET);
+    const res = await request(app)
+      .get(`/projects/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- add UserProjectAccess model to Prisma schema
- create middleware to authorize project access
- expose project read/update endpoints with authorization
- include user role in issued JWTs
- add in-memory data model for project access
- test project access control logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844fde4220883209f45c09d1b036fbc