### PR TITLE
Add company management API

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   accountId Int
 
   tasks Task[]
+  companies UserCompany[]
 
   @@unique([accountId, username])
 }
@@ -59,6 +60,8 @@ model Project {
   name      String
   account   Account  @relation(fields: [accountId], references: [id])
   accountId Int
+  company   Company  @relation(fields: [companyId], references: [id])
+  companyId Int
   createdAt DateTime @default(now())
 
   category   ProjectCategory? @relation(fields: [categoryId], references: [id])
@@ -93,5 +96,27 @@ model UserProjectAccess {
   role     String?
 
   @@id([userId, projectId])
+}
+
+model Company {
+  id        Int      @id @default(autoincrement())
+  name      String
+  account   Account  @relation(fields: [accountId], references: [id])
+  accountId Int
+  isMasterCompany Boolean @default(false)
+  createdAt DateTime @default(now())
+
+  users    UserCompany[]
+  projects Project[]
+}
+
+model UserCompany {
+  user     User    @relation(fields: [userId], references: [id])
+  userId   Int
+  company  Company @relation(fields: [companyId], references: [id])
+  companyId Int
+  role     String?
+
+  @@id([userId, companyId])
 }
 

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express';
+import { companies, userCompanies, Company, UserCompany } from '../models/Company';
+import { projects } from '../models/Project';
+
+let companyCounter = 1;
+
+export const createCompany = (req: Request, res: Response) => {
+  const { name, accountId, isMasterCompany } = req.body as {
+    name?: string;
+    accountId?: number;
+    isMasterCompany?: boolean;
+  };
+  if (!name || !accountId) {
+    return res.status(400).json({ error: 'name and accountId required' });
+  }
+  if (
+    isMasterCompany &&
+    companies.some((c) => c.accountId === accountId && c.isMasterCompany)
+  ) {
+    return res.status(400).json({ error: 'Master company already exists' });
+  }
+  const company: Company = {
+    id: companyCounter++,
+    name,
+    accountId,
+    isMasterCompany: Boolean(isMasterCompany),
+    createdAt: new Date(),
+  };
+  companies.push(company);
+  res.status(201).json(company);
+};
+
+export const assignUsersToCompany = (req: Request, res: Response) => {
+  const companyId = Number(req.params.id);
+  const { userIds, role } = req.body as { userIds?: number[]; role?: string };
+  if (!Array.isArray(userIds) || userIds.length === 0) {
+    return res.status(400).json({ error: 'userIds required' });
+  }
+  const company = companies.find((c) => c.id === companyId);
+  if (!company) {
+    return res.status(404).json({ error: 'Company not found' });
+  }
+  userIds.forEach((userId) => {
+    const existing = userCompanies.find(
+      (uc) => uc.userId === userId && uc.companyId === companyId
+    );
+    if (existing) {
+      existing.role = role;
+    } else {
+      const uc: UserCompany = { userId, companyId, role };
+      userCompanies.push(uc);
+    }
+  });
+  res.json({ success: true });
+};
+
+export const getCompany = (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const company = companies.find((c) => c.id === id);
+  if (!company) {
+    return res.status(404).json({ error: 'Company not found' });
+  }
+  const users = userCompanies
+    .filter((uc) => uc.companyId === id)
+    .map((uc) => ({ userId: uc.userId, role: uc.role }));
+  const companyProjects = projects.filter((p) => p.companyId === id);
+  res.json({ ...company, users, projects: companyProjects });
+};

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -59,13 +59,16 @@ export const deleteCategory = (req: Request, res: Response) => {
 };
 
 export const createProject = (req: Request, res: Response) => {
-  const { name, accountId, categoryId } = req.body as {
+  const { name, accountId, companyId, categoryId } = req.body as {
     name?: string;
     accountId?: number;
+    companyId?: number;
     categoryId?: number;
   };
-  if (!name || !accountId) {
-    return res.status(400).json({ error: 'Name and accountId required' });
+  if (!name || !accountId || !companyId) {
+    return res
+      .status(400)
+      .json({ error: 'Name, accountId and companyId required' });
   }
   let catId = categoryId;
   if (!catId) {
@@ -76,6 +79,7 @@ export const createProject = (req: Request, res: Response) => {
     id: projectCounter++,
     name,
     accountId,
+    companyId,
     createdAt: new Date(),
     categoryId: catId,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import jwt from 'jsonwebtoken';
 import boardRoutes from './routes/boards';
 import projectRoutes from './routes/projects';
 import taskRoutes from './routes/tasks';
+import companyRoutes from './routes/companies';
 dotenv.config();
 
 const app = express();
@@ -26,6 +27,7 @@ app.use(express.json());
 app.use(boardRoutes);
 app.use(projectRoutes);
 app.use(taskRoutes);
+app.use(companyRoutes);
 
 // Register new user
 app.post('/auth/register', async (req, res) => {

--- a/src/middleware/requireAdmin.ts
+++ b/src/middleware/requireAdmin.ts
@@ -1,10 +1,24 @@
 import { Request, Response, NextFunction } from 'express';
 import { UserRole } from '../roles';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 // Simple placeholder middleware to restrict routes to admins.
 export function requireAdmin(req: Request, res: Response, next: NextFunction) {
-  // In the future, extract user role from authentication token
-  const role = (req as any).userRole as UserRole | undefined;
+  let role = (req as any).userRole as UserRole | undefined;
+  if (!role) {
+    const auth = req.headers.authorization;
+    if (auth && auth.startsWith('Bearer ')) {
+      try {
+        const payload = jwt.verify(auth.split(' ')[1], JWT_SECRET) as any;
+        role = payload.role as UserRole | undefined;
+        (req as any).userRole = role;
+      } catch {
+        // ignore
+      }
+    }
+  }
   if (role === UserRole.ADMIN) {
     return next();
   }

--- a/src/models/Company.ts
+++ b/src/models/Company.ts
@@ -1,0 +1,16 @@
+export interface Company {
+  id: number;
+  name: string;
+  accountId: number;
+  isMasterCompany: boolean;
+  createdAt: Date;
+}
+
+export interface UserCompany {
+  userId: number;
+  companyId: number;
+  role?: string;
+}
+
+export const companies: Company[] = [];
+export const userCompanies: UserCompany[] = [];

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -9,6 +9,7 @@ export interface Project {
   id: number;
   name: string;
   accountId: number;
+  companyId: number;
   createdAt: Date;
   categoryId?: number;
 }

--- a/src/routes/companies.ts
+++ b/src/routes/companies.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import {
+  createCompany,
+  assignUsersToCompany,
+  getCompany,
+} from '../controllers/companyController';
+import { requireAdmin } from '../middleware/requireAdmin';
+
+const router = Router();
+
+router.post('/companies', requireAdmin, createCompany);
+router.post('/companies/:id/users', requireAdmin, assignUsersToCompany);
+router.get('/companies/:id', getCompany);
+
+export default router;

--- a/tests/companies.test.ts
+++ b/tests/companies.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import app from '../src/index';
+import { companies, userCompanies } from '../src/models/Company';
+import { projects } from '../src/models/Project';
+import jwt from 'jsonwebtoken';
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+describe('Companies API', () => {
+  beforeEach(() => {
+    companies.length = 0;
+    userCompanies.length = 0;
+    projects.length = 0;
+  });
+
+  it('creates master company and prevents duplicate', async () => {
+    const token = jwt.sign({ userId: 1, role: 'ADMIN' }, SECRET);
+    const first = await request(app)
+      .post('/companies')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Master', accountId: 1, isMasterCompany: true });
+    expect(first.status).toBe(201);
+
+    const dup = await request(app)
+      .post('/companies')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Another', accountId: 1, isMasterCompany: true });
+    expect(dup.status).toBe(400);
+  });
+
+  it('assigns users and links projects', async () => {
+    const token = jwt.sign({ userId: 1, role: 'ADMIN' }, SECRET);
+    const companyRes = await request(app)
+      .post('/companies')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'C', accountId: 1 });
+    const companyId = companyRes.body.id;
+
+    await request(app)
+      .post(`/companies/${companyId}/users`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ userIds: [1, 2], role: 'MEMBER' })
+      .expect(200);
+
+    const proj = await request(app)
+      .post('/projects')
+      .send({ name: 'P', accountId: 1, companyId });
+    expect(proj.status).toBe(201);
+
+    const get = await request(app).get(`/companies/${companyId}`);
+    expect(get.body.users.length).toBe(2);
+    expect(get.body.projects[0].id).toBe(proj.body.id);
+  });
+});

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -36,7 +36,7 @@ describe('Project categories API', () => {
   it('assigns default category when creating a project', async () => {
     const res = await request(app)
       .post('/projects')
-      .send({ name: 'Proj', accountId: 2 });
+      .send({ name: 'Proj', accountId: 2, companyId: 1 });
     expect(res.status).toBe(201);
     expect(res.body.categoryId).toBeDefined();
     const cats = await request(app).get('/categories?accountId=2');
@@ -53,7 +53,7 @@ describe('Project access control', () => {
   it('denies access when user lacks permission', async () => {
     const create = await request(app)
       .post('/projects')
-      .send({ name: 'A', accountId: 1 });
+      .send({ name: 'A', accountId: 1, companyId: 1 });
     const id = create.body.id;
     const token = jwt.sign({ userId: 1, role: 'BASIC' }, SECRET);
     const res = await request(app)
@@ -65,7 +65,7 @@ describe('Project access control', () => {
   it('allows access when entry exists', async () => {
     const create = await request(app)
       .post('/projects')
-      .send({ name: 'A', accountId: 1 });
+      .send({ name: 'A', accountId: 1, companyId: 1 });
     const id = create.body.id;
     userProjectAccess.push({ userId: 1, projectId: id });
     const token = jwt.sign({ userId: 1, role: 'BASIC' }, SECRET);
@@ -78,7 +78,7 @@ describe('Project access control', () => {
   it('allows admin regardless of entry', async () => {
     const create = await request(app)
       .post('/projects')
-      .send({ name: 'A', accountId: 1 });
+      .send({ name: 'A', accountId: 1, companyId: 1 });
     const id = create.body.id;
     const token = jwt.sign({ userId: 2, role: 'ADMIN' }, SECRET);
     const res = await request(app)


### PR DESCRIPTION
## Summary
- update Prisma schema with `Company` and `UserCompany`
- allow projects to belong to a company
- add company models and controller
- add routes for creating companies, assigning users and fetching info
- enforce admin check via updated middleware
- require `companyId` when creating projects
- test new company flows and updated project creation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844ff866d6c8320b91aa1f6f3b2d38f