### PR TITLE
Implement account registration system

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,0 +1,76 @@
+import { Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { accounts, Account } from '../models/Account';
+import { users, User } from '../models/User';
+import { companies, Company } from '../models/Company';
+import { UserRole } from '../roles';
+
+let accountCounter = 1;
+let userCounter = 1;
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+export const createAccount = (req: Request, res: Response) => {
+  const { name, createMasterCompany } = req.body as {
+    name?: string;
+    createMasterCompany?: boolean;
+  };
+  if (!name) {
+    return res.status(400).json({ error: 'name required' });
+  }
+  if (accounts.some((a) => a.name === name)) {
+    return res.status(400).json({ error: 'Account name already exists' });
+  }
+  const account: Account = {
+    id: accountCounter++,
+    name,
+    createdAt: new Date(),
+  };
+  accounts.push(account);
+
+  if (createMasterCompany) {
+    const company: Company = {
+      id: companies.length + 1,
+      name: `${name} Master`,
+      accountId: account.id,
+      isMasterCompany: true,
+      createdAt: new Date(),
+    };
+    companies.push(company);
+  }
+
+  res.status(201).json(account);
+};
+
+export const registerUser = async (req: Request, res: Response) => {
+  const accountId = Number(req.params.accountId);
+  const { username, password, role } = req.body as {
+    username?: string;
+    password?: string;
+    role?: UserRole;
+  };
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username and password required' });
+  }
+  const account = accounts.find((a) => a.id === accountId);
+  if (!account) {
+    return res.status(404).json({ error: 'Account not found' });
+  }
+  if (users.some((u) => u.username === username && u.accountId === accountId)) {
+    return res.status(409).json({ error: 'Username already exists' });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  const user: User = {
+    id: userCounter++,
+    username,
+    password: hashed,
+    role: role || UserRole.BASIC,
+    accountId,
+    createdAt: new Date(),
+  };
+  users.push(user);
+
+  const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
+  res.status(201).json({ token });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import boardRoutes from './routes/boards';
 import projectRoutes from './routes/projects';
 import taskRoutes from './routes/tasks';
 import companyRoutes from './routes/companies';
+import authRoutes from './routes/auth';
 dotenv.config();
 
 const app = express();
@@ -28,6 +29,7 @@ app.use(boardRoutes);
 app.use(projectRoutes);
 app.use(taskRoutes);
 app.use(companyRoutes);
+app.use(authRoutes);
 
 // Register new user
 app.post('/auth/register', async (req, res) => {

--- a/src/models/Account.ts
+++ b/src/models/Account.ts
@@ -1,0 +1,7 @@
+export interface Account {
+  id: number;
+  name: string;
+  createdAt: Date;
+}
+
+export const accounts: Account[] = [];

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,12 @@
+import { UserRole } from '../roles';
+
+export interface User {
+  id: number;
+  username: string;
+  password: string;
+  role: UserRole;
+  accountId: number;
+  createdAt: Date;
+}
+
+export const users: User[] = [];

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function Register() {
+  const [accountName, setAccountName] = useState('');
+  const [accountId, setAccountId] = useState<number | null>(null);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const createAccount = async () => {
+    const res = await axios.post('/accounts', { name: accountName });
+    setAccountId(res.data.id);
+  };
+
+  const register = async () => {
+    if (accountId == null) return;
+    await axios.post(`/accounts/${accountId}/users`, { username, password });
+  };
+
+  return (
+    <div>
+      {accountId == null ? (
+        <div>
+          <input
+            value={accountName}
+            onChange={(e) => setAccountName(e.target.value)}
+            placeholder="Account name"
+          />
+          <button onClick={createAccount}>Create Account</button>
+        </div>
+      ) : (
+        <div>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          <button onClick={register}>Register</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { createAccount, registerUser } from '../controllers/authController';
+
+const router = Router();
+
+router.post('/accounts', createAccount);
+router.post('/accounts/:accountId/users', registerUser);
+
+export default router;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import app from '../src/index';
+import { accounts } from '../src/models/Account';
+import { users } from '../src/models/User';
+
+describe('Account and user registration', () => {
+  beforeEach(() => {
+    accounts.length = 0;
+    users.length = 0;
+  });
+
+  it('creates a new account', async () => {
+    const res = await request(app).post('/accounts').send({ name: 'Acme' });
+    expect(res.status).toBe(201);
+    expect(accounts.length).toBe(1);
+    expect(accounts[0].name).toBe('Acme');
+
+    const dup = await request(app).post('/accounts').send({ name: 'Acme' });
+    expect(dup.status).toBe(400);
+  });
+
+  it('registers a user linked to an account', async () => {
+    const acc = await request(app).post('/accounts').send({ name: 'Org' });
+    const accountId = acc.body.id;
+    const res = await request(app)
+      .post(`/accounts/${accountId}/users`)
+      .send({ username: 'user1', password: 'pass' });
+    expect(res.status).toBe(201);
+    expect(users.length).toBe(1);
+    expect(users[0].accountId).toBe(accountId);
+    expect(users[0].role).toBe('BASIC');
+  });
+});


### PR DESCRIPTION
## Summary
- add in-memory Account and User models
- implement account creation and per-account user registration
- expose new routes for `/accounts` and `/accounts/:accountId/users`
- wire up new auth routes in the server
- provide frontend registration example with account flow
- test account and user registration logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684501aae64c832097adbe2a335434a5