### PR TITLE
Add CLI script for user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ KeepUp aims to be scalable with features such as:
 
 Use `/auth/register` to create a new user with a JSON body containing `username` and `password`. Log in via `/auth/login` with the same fields to receive a JWT token.
 
+### Adding a user via script
+
+For development you can also create a user from the command line. Set the
+environment variables `USER_EMAIL`, `USER_PASSWORD` and `ACCOUNT_ID` then run:
+
+```bash
+npx ts-node scripts/createUser.ts
+```
+
+This will create a BASIC role user under the specified account.
+
 This README outlines the current vision and early development goals for KeepUp. The codebase is intentionally minimal as the project is in its initial stages.
 
 ## Project Categories API

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "start": "node dist/index.js",
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
-    "test": "jest"
+    "test": "jest",
+    "create-user": "ts-node scripts/createUser.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/createUser.ts
+++ b/scripts/createUser.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+async function main() {
+  const email = process.env.USER_EMAIL;
+  const password = process.env.USER_PASSWORD;
+  const accountIdStr = process.env.ACCOUNT_ID;
+  if (!email || !password || !accountIdStr) {
+    console.error('USER_EMAIL, USER_PASSWORD and ACCOUNT_ID env vars are required');
+    process.exit(1);
+  }
+
+  const accountId = Number(accountIdStr);
+  const prisma = new PrismaClient();
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: { username: email, password: hashed, role: 'BASIC', accountId }
+    });
+    console.log('Created user with id', user.id);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/createUser.ts` for creating users via command line
- document how to use the script in the README
- expose a `create-user` npm script in `package.json`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684522a3be348320856b827778692769