### PR TITLE
Fix missing Prisma relation fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,9 @@ model Account {
   createdAt DateTime @default(now())
 
   users     User[]
+  projectCategories ProjectCategory[]
+  projects          Project[]
+  companies         Company[]
 }
 
 model User {
@@ -41,6 +44,7 @@ model User {
 
   tasks Task[]
   companies UserCompany[]
+  projectAccesses UserProjectAccess[]
 
   @@unique([accountId, username])
 }
@@ -66,6 +70,8 @@ model Project {
 
   category   ProjectCategory? @relation(fields: [categoryId], references: [id])
   categoryId Int?
+
+  userAccesses UserProjectAccess[]
 }
 
 enum Priority {


### PR DESCRIPTION
## Summary
- add missing relation arrays to `Account`, `User`, and `Project`
- these complete the opposite sides required by Prisma

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845c7998a388320913138b88c324389