### PR TITLE
Add timelog validation check

### DIFF
--- a/src/controllers/taskController.ts
+++ b/src/controllers/taskController.ts
@@ -80,6 +80,10 @@ export const logTime = (req: Request, res: Response): void => {
     res.status(400).json({ error: 'Invalid dates' });
     return;
   }
+  if (endDate <= startDate) {
+    res.status(400).json({ error: 'end must be after start' });
+    return;
+  }
   const totalMs = endDate.getTime() - startDate.getTime();
   const log: TimeLog = {
     id: timeLogCounter++,

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -49,6 +49,18 @@ describe('Tasks API', () => {
     expect(log.body.totalMs).toBe(3600000);
   });
 
+  it('rejects time logs where end precedes start', async () => {
+    const create = await request(app).post('/tasks').send({ name: 'T' });
+    const taskId = create.body.taskId;
+    const res = await request(app)
+      .post(`/tasks/${taskId}/timelogs`)
+      .send({
+        start: '2024-01-01T01:00:00.000Z',
+        end: '2024-01-01T00:00:00.000Z',
+      });
+    expect(res.status).toBe(400);
+  });
+
   it('assigns tags to a task', async () => {
     const tag = await request(app).post('/tags').send({ name: 'bug' });
     const tagId = tag.body.id;


### PR DESCRIPTION
## Summary
- prevent creating a time log when the end date is before the start date
- test time log validation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f2c98a5c83209e45c915b4af01ea