### PR TITLE
Validate project ID

### DIFF
--- a/src/middleware/authorizeProjectAccess.ts
+++ b/src/middleware/authorizeProjectAccess.ts
@@ -28,6 +28,10 @@ export function authorizeProjectAccess(projectIdParamKey: string) {
         return;
       }
       const projectId = Number(req.params[projectIdParamKey]);
+      if (Number.isNaN(projectId)) {
+        res.status(400).json({ error: 'Invalid project ID' });
+        return;
+      }
       if (
         userProjectAccess.some(
           (a) => a.userId === userId && a.projectId === projectId

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -86,4 +86,12 @@ describe('Project access control', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
   });
+
+  it('returns 400 for non-numeric project ID', async () => {
+    const token = jwt.sign({ userId: 1, role: 'BASIC' }, SECRET);
+    const res = await request(app)
+      .get('/projects/abc')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary
- validate project ID in `authorizeProjectAccess`
- test that non-numeric project ID returns 400

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f2de536c8320aef789240a6ea477