### PR TITLE
Skip auth routes when testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ KeepUp aims to be scalable with features such as:
 ## Authentication
 
 Use `/auth/register` to create a new user with a JSON body containing `username` and `password`. Log in via `/auth/login` with the same fields to receive a JWT token.
+When `NODE_ENV` is set to `test` (for example during Jest runs), these two routes are disabled.
 
 ### Adding a user via script
 
@@ -117,6 +118,7 @@ Below is a quick reference for the available endpoints.
 ### Authentication
 - `POST /auth/register` – Registers a user using `{ username, password }` and returns `{ token }`.
 - `POST /auth/login` – Logs in with `{ username, password }` and returns `{ token }`.
+Both endpoints are skipped when `NODE_ENV=test`.
 
 ### Accounts & Users
 - `POST /accounts` – Create an account via `{ name }`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,44 +31,46 @@ app.use(taskRoutes);
 app.use(companyRoutes);
 app.use(authRoutes);
 
-// Register new user
-app.post('/auth/register', async (req, res): Promise<void> => {
-  const { username, password } = req.body as { username?: string; password?: string };
-  if (!username || !password) {
-    res.status(400).json({ error: 'Username and password required' });
-    return;
-  }
-  const existing = await prisma.user.findUnique({ where: { username } });
-  if (existing) {
-    res.status(409).json({ error: 'Username already exists' });
-    return;
-  }
-  const hashed = await bcrypt.hash(password, 10);
-  const user = await prisma.user.create({ data: { username, password: hashed } });
-  const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
-  res.json({ token });
-});
+if (process.env.NODE_ENV !== 'test') {
+  // Register new user
+  app.post('/auth/register', async (req, res): Promise<void> => {
+    const { username, password } = req.body as { username?: string; password?: string };
+    if (!username || !password) {
+      res.status(400).json({ error: 'Username and password required' });
+      return;
+    }
+    const existing = await prisma.user.findUnique({ where: { username } });
+    if (existing) {
+      res.status(409).json({ error: 'Username already exists' });
+      return;
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({ data: { username, password: hashed } });
+    const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
+    res.json({ token });
+  });
 
-// Login existing user
-app.post('/auth/login', async (req, res): Promise<void> => {
-  const { username, password } = req.body as { username?: string; password?: string };
-  if (!username || !password) {
-    res.status(400).json({ error: 'Username and password required' });
-    return;
-  }
-  const user = await prisma.user.findUnique({ where: { username } });
-  if (!user) {
-    res.status(401).json({ error: 'Invalid credentials' });
-    return;
-  }
-  const valid = await bcrypt.compare(password, user.password);
-  if (!valid) {
-    res.status(401).json({ error: 'Invalid credentials' });
-    return;
-  }
-  const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
-  res.json({ token });
-});
+  // Login existing user
+  app.post('/auth/login', async (req, res): Promise<void> => {
+    const { username, password } = req.body as { username?: string; password?: string };
+    if (!username || !password) {
+      res.status(400).json({ error: 'Username and password required' });
+      return;
+    }
+    const user = await prisma.user.findUnique({ where: { username } });
+    if (!user) {
+      res.status(401).json({ error: 'Invalid credentials' });
+      return;
+    }
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      res.status(401).json({ error: 'Invalid credentials' });
+      return;
+    }
+    const token = jwt.sign({ userId: user.id, role: user.role }, JWT_SECRET);
+    res.json({ token });
+  });
+}
 
 // Health-check route
 app.get('/health', (_req, res) => {

--- a/tests/auth-disabled.test.ts
+++ b/tests/auth-disabled.test.ts
@@ -1,0 +1,16 @@
+import request from 'supertest';
+import app from '../src/index';
+
+describe('Auth routes in test mode', () => {
+  it('returns 404 when register and login routes are disabled', async () => {
+    const register = await request(app)
+      .post('/auth/register')
+      .send({ username: 'a', password: 'b' });
+    expect(register.status).toBe(404);
+
+    const login = await request(app)
+      .post('/auth/login')
+      .send({ username: 'a', password: 'b' });
+    expect(login.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- disable `/auth/register` and `/auth/login` in test mode
- document test-mode behavior
- add test covering disabled auth routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f2e276088320aac22378a884f35b