### PR TITLE
Add role validation for user registration

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -65,6 +65,11 @@ export const registerUser = async (req: Request, res: Response): Promise<void> =
     res.status(409).json({ error: 'Username already exists' });
     return;
   }
+  const allowedRoles = [UserRole.ADMIN, UserRole.BASIC];
+  if (role && !allowedRoles.includes(role)) {
+    res.status(400).json({ error: 'Invalid role' });
+    return;
+  }
   const hashed = await bcrypt.hash(password, 10);
   const user: User = {
     id: userCounter++,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -30,4 +30,21 @@ describe('Account and user registration', () => {
     expect(users[0].accountId).toBe(accountId);
     expect(users[0].role).toBe('BASIC');
   });
+
+  it('validates role when registering user', async () => {
+    const acc = await request(app).post('/accounts').send({ name: 'RoleOrg' });
+    const accountId = acc.body.id;
+
+    const adminRes = await request(app)
+      .post(`/accounts/${accountId}/users`)
+      .send({ username: 'admin', password: 'pass', role: 'ADMIN' });
+    expect(adminRes.status).toBe(201);
+    expect(users[0].role).toBe('ADMIN');
+
+    const invalid = await request(app)
+      .post(`/accounts/${accountId}/users`)
+      .send({ username: 'bad', password: 'pass', role: 'INVALID' });
+    expect(invalid.status).toBe(400);
+    expect(users.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- validate `role` in `registerUser` against `ADMIN` and `BASIC`
- return `400 Bad Request` for invalid role values
- add unit tests for role validation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6845f658785483208603f95aa58b937e