### PR TITLE
Add validation for task dates and priority

### DIFF
--- a/src/controllers/taskController.ts
+++ b/src/controllers/taskController.ts
@@ -20,7 +20,9 @@ function generateShortId() {
 
 export const createTask = (req: Request, res: Response): void => {
   const { name, description, startDate, dueDate, priority, assignedUserIds } =
-    req.body as Partial<Omit<Task, 'id' | 'taskId' | 'createdAt' | 'updatedAt'>> & {
+    req.body as Partial<
+      Omit<Task, 'id' | 'taskId' | 'createdAt' | 'updatedAt'>
+    > & {
       assignedUserIds?: number[];
     };
 
@@ -33,14 +35,37 @@ export const createTask = (req: Request, res: Response): void => {
     return;
   }
 
+  let parsedStart: Date | undefined;
+  if (startDate) {
+    parsedStart = new Date(startDate);
+    if (isNaN(parsedStart.getTime())) {
+      res.status(400).json({ error: 'Invalid startDate' });
+      return;
+    }
+  }
+
+  let parsedDue: Date | undefined;
+  if (dueDate) {
+    parsedDue = new Date(dueDate);
+    if (isNaN(parsedDue.getTime())) {
+      res.status(400).json({ error: 'Invalid dueDate' });
+      return;
+    }
+  }
+
+  if (priority && !['LOW', 'MEDIUM', 'HIGH'].includes(priority)) {
+    res.status(400).json({ error: 'Invalid priority' });
+    return;
+  }
+
   const now = new Date();
   const task: Task = {
     id: idCounter++,
     taskId: generateShortId(),
     name,
     description,
-    startDate: startDate ? new Date(startDate) : undefined,
-    dueDate: dueDate ? new Date(dueDate) : undefined,
+    startDate: parsedStart,
+    dueDate: parsedDue,
     priority: (priority as Task['priority']) || 'MEDIUM',
     createdAt: now,
     updatedAt: now,

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -36,6 +36,30 @@ describe('Tasks API', () => {
     expect(getRes.body.assignedUserIds.length).toBe(2);
   });
 
+  it('rejects invalid startDate', async () => {
+    const res = await request(app).post('/tasks').send({
+      name: 'Bad',
+      startDate: 'not-a-date',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid dueDate', async () => {
+    const res = await request(app).post('/tasks').send({
+      name: 'Bad',
+      dueDate: 'also-bad',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid priority', async () => {
+    const res = await request(app).post('/tasks').send({
+      name: 'Bad',
+      priority: 'URGENT',
+    });
+    expect(res.status).toBe(400);
+  });
+
   it('logs time and computes total', async () => {
     const create = await request(app).post('/tasks').send({ name: 'T' });
     const taskId = create.body.taskId;


### PR DESCRIPTION
## Summary
- validate `startDate` and `dueDate` in `createTask`
- validate `priority` value
- add tests for invalid date and priority values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f65736f48320bdeae1b8284bce62