### PR TITLE
Fix TypeScript DOM errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es6"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es6", "dom"],                               /* Include DOM lib for browser APIs. */
     "jsx": "react-jsx",                                  /* Use the React 17+ JSX runtime. */
     // "libReplacement": true,                           /* Enable lib replacement. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
## Summary
- allow DOM types in tsconfig so React inputs compile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6848ccc020c88320b46c52dfba56c52f